### PR TITLE
Builds view specific office route

### DIFF
--- a/app/v1/views/politicaloffices.py
+++ b/app/v1/views/politicaloffices.py
@@ -1,5 +1,5 @@
 
-from flask import Flask, make_response, jsonify, request, Blueprint
+from flask import Flask, make_response, jsonify, request, Blueprint, abort
 from .politicalmain import api
 
 app = Flask(__name__)
@@ -18,13 +18,13 @@ def add_politicaloffices():
     """
     if request.method == "POST":
         data = request.get_json()
-        type = data ['type']
+        office_type = data ['office_type']
         name = data ['name']
         
 
         new_politicaloffice = { 
                 "id": generate_id(politicaloffices_list),
-                "type" : type ,
+                "type" : office_type ,
                 "name" : name 
                 
                 }
@@ -35,7 +35,7 @@ def add_politicaloffices():
             "Message": "New Political Office Created",
             "office name": new_politicaloffice['name'],
             "office id": new_politicaloffice['id'],
-    }), 201)
+            }), 201)
 
     elif request.method == "GET":
         #Get all political offices - GET request
@@ -43,4 +43,19 @@ def add_politicaloffices():
                 "offices": politicaloffices_list,
                 "status": "Ok"
             }), 200)
+
+@api.route('/politicaloffices/<int:id>', methods = ["GET"])
+def specific_politicaloffice(id):
+    #View specific political party - GET request
+    new_politicaloffice = [new_politicaloffice for new_politicaloffice in politicaloffices_list if new_politicaloffice['id'] == id]
+    
+    if len(new_politicaloffice) == 0:
+        abort(404, 'Office does not exist')
+
+    if request.method == 'GET':
+        return make_response(jsonify({
+                    "parties": politicaloffices_list,
+                    "status": "Ok"
+                }), 200)
+
 

--- a/tests/test_office_routes.py
+++ b/tests/test_office_routes.py
@@ -12,7 +12,7 @@ class PoliticalOfficesTestCase(unittest.TestCase):
         self.app = create_app(config_name="testing")
         self.client = self.app.test_client()
         self.politicaloffice = { 
-            "type" : "County" ,
+            "office_type" : "County" ,
             "name" : "Governor Kiambu" 
             }
 
@@ -28,5 +28,5 @@ class PoliticalOfficesTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_view_specific_office(self):
-        response = self.client.get('/api/v1/politicalparties/1', json=self.politicaloffice)
+        response = self.client.get('/api/v1/politicaloffices/1', json=self.politicaloffice)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
**What does this PR do?**
Adds a route to view specific office given the id

**Description of Task to be completed?**

* * A political office is created by sending a **GET** to the endpoint _127.0.0.1:5000/api/v1/politicaloffices/<id>
* * A response with a payload of the form below is returned if successful
    `{
    "parties": [
        {
            "id": 1,
            "name": "Governor Kiambu",
            "type": "County"
        }
    ],
    "status": "Ok"
}`

**How should this be manually tested?**
After cloning this repo, and installing dependencies via `* pip install -r requirements.txt` . Run `flask run` and test [127.0.0.1:5000/api/v1/politicaloffices/1](url) GET request via Postman after creating a office

What are the relevant pivotal tracker stories?
#163682549

**Screenshots**
![viewspecificoffice](https://user-images.githubusercontent.com/31648909/52325778-5e768f80-29f7-11e9-9c66-381bca5f5470.png)
