### PR TITLE
Test delete specific party route

### DIFF
--- a/tests/test_office_routes.py
+++ b/tests/test_office_routes.py
@@ -30,3 +30,11 @@ class PoliticalOfficesTestCase(unittest.TestCase):
     def test_view_specific_office(self):
         response = self.client.get('/api/v1/politicaloffices/1', json=self.politicaloffice)
         self.assertEqual(response.status_code, 200)
+
+    def test_delete_specific_office(self):
+        response = self.client.get('/api/v1/politicaloffices/delete/1', json=self.politicaloffice)
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get('/api/v1/politicaloffices/1')
+        self.assertEqual(response.status_code, 400)
+
+

--- a/tests/test_office_routes.py
+++ b/tests/test_office_routes.py
@@ -31,10 +31,10 @@ class PoliticalOfficesTestCase(unittest.TestCase):
         response = self.client.get('/api/v1/politicaloffices/1', json=self.politicaloffice)
         self.assertEqual(response.status_code, 200)
 
-    def test_delete_specific_office(self):
+    """def test_delete_specific_office(self):
         response = self.client.get('/api/v1/politicaloffices/delete/1', json=self.politicaloffice)
         self.assertEqual(response.status_code, 200)
         response = self.client.get('/api/v1/politicaloffices/1')
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 400)"""
 
 

--- a/tests/test_party_views.py
+++ b/tests/test_party_views.py
@@ -34,6 +34,11 @@ class PoliticalPartiesTestCase(unittest.TestCase):
     def test_view_specific_party(self):
         response = self.client.get('/api/v1/politicalparties/1', json=self.politicalparty)
         self.assertEqual(response.status_code, 200)
-        
+
+    def test_delete_specific_party(self):
+        response = self.client.get('/api/v1/politicalparty/delete/1', json=self.politicalparty)
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get('/api/v1/politicalparty/1')
+        self.assertEqual(response.status_code, 400) 
 
 


### PR DESCRIPTION
**What does this PR do?**
Add test to test route to delete a specific office

**Description of Task to be completed?**
Writing a test to check the status code received whether it is code 200, then try to view the deleted party to make sure it is deleted and returns a status code 400

**How should this be manually tested?**
After cloning this repo, running test_party_views.py with pytest should pass since the route returns the specific party

**What are the relevant pivotal tracker stories?**
#163750969