### PR TITLE
Builds edit specific party name route

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 
 
 script:
-  - nosetests -v test/
+  - pytest --cov=app
 
 after_success:
   - coveralls

--- a/app/v1/views/politicalparties.py
+++ b/app/v1/views/politicalparties.py
@@ -49,7 +49,7 @@ def add_politicalparties():
                 "status": "Ok"
             }), 200)
 
-@api.route('/politicalparties/<int:id>', methods = ["GET", "DELETE", "PUT"])
+@api.route('/politicalparties/<int:id>', methods = ["GET", "DELETE"])
 def specific_politicalparty(id):
     #View specific political party - GET request
     new_politicalparty = [new_politicalparty for new_politicalparty in politicalparties_list if new_politicalparty['id'] == id]
@@ -67,8 +67,37 @@ def specific_politicalparty(id):
         
         new_politicalparty.pop
 
-        return make_response(jsonify({"msg": "Party with id {} id deleted".format(id)
+        return make_response(jsonify({"msg": "Party with id {} deleted".format(id)
 
                 }), 200)
+    
+
+@api.route('/politicalparties/<int:id>/<string:name>', methods = ["PATCH"])
+def edit_party_name(id, name):
+    
+    
+
+    
+    
+    for i in range(len(politicalparties_list)):
+        if politicalparties_list[i]['id'] == id:
+            politicalparty = politicalparties_list[i]
+            politicalparty['name'] = name
+            politicalparties_list[i] = politicalparty
+            break
+    
+    
+    return make_response(jsonify({
+                "Message": "Party name changed for {} ".format(id),
+                
+                "party": [politicalparty],
+            }), 200)
+    
+
+    
+    
+
+
+
 
     

--- a/tests/test_party_views.py
+++ b/tests/test_party_views.py
@@ -13,7 +13,7 @@ class PoliticalPartiesTestCase(unittest.TestCase):
         self.app = create_app(config_name="testing")
         self.client = self.app.test_client()
         self.politicalparty = { 
-            "id" : 1,
+          
             "name" : "African Liberation Party" ,
             "abbreviation" : "ALP" ,
             "members" : "15" ,
@@ -35,6 +35,8 @@ class PoliticalPartiesTestCase(unittest.TestCase):
     def test_view_specific_party(self):
         response = self.client.get('/api/v1/politicalparties/1', json=self.politicalparty)
         self.assertEqual(response.status_code, 200)
+    
+
 
     def test_delete_specific_party(self):
         
@@ -42,10 +44,10 @@ class PoliticalPartiesTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_edit_specific_party(self):
-        
         self.client.post('/api/v1/politicalparties', json=self.politicalparty)
+
         response = self.client.patch('/api/v1/politicalparties/1/Orange')
+
         self.assertEqual(response.status_code, 200)
         
-
 


### PR DESCRIPTION
**What does this PR do?**
Adds a route to edit specific party name given the id and new name

**Description of Task to be completed?**

* * A political office is created by sending a **POST** to the endpoint _127.0.0.1:5000/api/v1/politicaloffices/<int:id>/name_ 
* * A response with a payload of the form below is returned if successful
    `{
    "Message": "Party name changed for 1 ",
    "party": [
        {
            "abbreviation": "abbreviation",
            "chairperson": "chairperson",
            "headquarters": "headquarters",
            "id": 1,
            "members": "members",
            "name": "kkk"
        }
    ]
}`

**How should this be manually tested?**
After cloning this repo, and installing dependencies via `* pip install -r requirements.txt` . Run `flask run` and test [127.0.0.1:5000/api/v1/politicalparties/1/juice](url) PATCH request via Postman after creating a party

**What are the relevant pivotal tracker stories?**
#163675092

**Screenshots**
![patchparty](https://user-images.githubusercontent.com/31648909/52389599-41989580-2aa5-11e9-9177-b08f691c9247.png)
